### PR TITLE
adds agent config, and cleans up docker code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ ADD .npmrc ./
 ADD package.json package-lock.json ./
 RUN npm install
 ADD . .
-CMD [ "npm", "run", "start" ]
+CMD [ "npm", "run", "start:debug" ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
-# aries-guardianship-agency
+# Aries Guardianship Agency
 
+### Setup
 For now you need to run the indy ledger and wallets db from the protocol repo
-You will als need to add your .env vars from another repo
-If you run into conflicts with docker images from another file run: docker rm -f $(docker ps -aq)
-To run the tests use: npm run test
+  TODO add a docker-compose here that can spin those up
+You will also need to add your .env vars from another repo
+  TODO figure out a good way to pass those .env vars in
+Once you have another docker compose running with the ledger and wallet db on kiva-network and .env in place you can run:
+```
+npm run install
+docker-compose up
+```
+To run tests:
+```
+npm run test
+```
+
+If you run into conflicts with docker images from another file clean things up with: docker rm -f $(docker ps -aq)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-#
+# Docker compose to spin up agency
+# Currently expects the ledger and wallet db to be available on the kiva-network
 #
 version: '3'
 
@@ -7,13 +8,13 @@ networks:
     external: true
 
 services:
-  protocol-agency-controller:
+  guardianship-agency:
     env_file:
       - ./.env
     build: ./
     command: npm run start:debug
-    image: protocol-agency-controller
-    container_name: protocol-agency-controller
+    image: guardianship-agency
+    container_name: guardianship-agency
     working_dir: /www
     ports:
       - "3010:3010"
@@ -24,47 +25,5 @@ services:
       - //var/run/docker.sock:/var/run/docker.sock
     networks:
       - kiva-network
-    depends_on:
-      - protocol-steward-agent
     tty: true
 
-  protocol-steward-agent:
-    image: bcgovimages/aries-cloudagent:py36-1.14-1_0.5.1
-    container_name: protocol-steward-agent
-    ports:
-      - ${STEWARD_AGENT_ADMIN_PORT}:${STEWARD_AGENT_ADMIN_PORT}
-      - ${STEWARD_AGENT_HTTP_PORT}:${STEWARD_AGENT_HTTP_PORT}
-    entrypoint: /bin/bash
-    command: [
-      "-c",
-      "sleep 14;
-          aca-py start \
-          --inbound-transport http '0.0.0.0' ${STEWARD_AGENT_HTTP_PORT} \
-          --outbound-transport http \
-          --endpoint ${STEWARD_AGENT_ENDPOINT} \
-          --genesis-file '${INDY_POOL_TRANSACTIONS_GENESIS_PATH}' \
-          --wallet-type 'indy' \
-          --wallet-name '${STEWARD_WALLET_ID}' \
-          --wallet-key '${STEWARD_WALLET_KEY}' \
-          --wallet-storage-type '${WALLET_TYPE}' \
-          --wallet-storage-config '{\"url\":\"${WALLET_DB_HOST}:${WALLET_DB_PORT}\",\"wallet_scheme\":\"MultiWalletSingleTable\"}' \
-          --wallet-storage-creds '{\"account\":\"${POSTGRES_USER}\",\"password\":\"${POSTGRES_PASSWORD}\",\"admin_account\":\"${POSTGRES_USER}\",\"admin_password\":\"${POSTGRES_PASSWORD}\"}' \
-          --seed '${STEWARD_AGENT_SEED}' \
-          --admin '0.0.0.0' ${STEWARD_AGENT_ADMIN_PORT} \
-          --admin-api-key '${STEWARD_ADMIN_API_KEY}' \
-          --label ${STEWARD_AGENT_NAME} \
-          --webhook-url ${STEWARD_CONTROLLER_WEB_HOOK_URL} \
-          --log-level debug \
-          --auto-accept-invites \
-          --auto-accept-requests",
-    ]
-    env_file:
-      - ./.env
-    volumes:
-      - ./resources:/home/indy/resources/
-    networks:
-      - kiva-network
-    tty: true
-
-volumes:
-  node_modules:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3650,6 +3650,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "express-opentracing": "^0.1.1",
     "express-rate-limit": "^5.1.3",
     "express-request-id": "1.4.1",
+    "fs": "0.0.1-security",
     "helmet": "^3.23.1",
     "http-proxy-middleware": "^1.0.4",
     "jaeger-client": "^3.18.0",

--- a/src/app/app.controller.ts
+++ b/src/app/app.controller.ts
@@ -1,5 +1,6 @@
 import { Get, Controller } from '@nestjs/common';
 import { HttpConstants } from '@kiva/protocol-common/http-context/http.constants';
+import { AgentConfig } from '../manager/agent.config';
 
 /**
  * Base route is just for various health check endpoints
@@ -20,5 +21,13 @@ export class AppController {
     @Get('healthz')
     healthz(): string {
         return HttpConstants.HEALTHZ_RESPONSE;
+    }
+
+    /**
+     * This is strictly needed, but could be useful for external users
+     */
+    @Get('genesis-file')
+    getGenesisFile(): string {
+        return AgentConfig.getGenesisFile();
     }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,5 @@ import { AgentControllerModule } from '../controller/agent.controller.module';
     ],
     controllers: [AppController],
     providers: [AppService],
-    exports: []
 })
 export class AppModule {}

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -19,7 +19,6 @@ export class AppService {
      * Sets up app in a way that can be used by main.ts and e2e tests
      */
     public static async setup(app: INestApplication) {
-
         // Setting request-id middleware which assigns a unique requestid per incomming requests if not sent by client.
         const requestId = require('express-request-id')();
         app.use(requestId);
@@ -56,8 +55,5 @@ export class AppService {
             const document = SwaggerModule.createDocument(app, options);
             SwaggerModule.setup('api-docs', app, document);
         }
-
-
-
     }
 }

--- a/src/config/env.json
+++ b/src/config/env.json
@@ -1,24 +1,24 @@
 {
   "default": {
-    "PORT": 3010,
-    "SERVICE_NAME": "guardianship_agency",
-    "MANAGER_TYPE": "K8S",
     "DD_AGENT_HOST": "datadog-statsd.datadog",
     "DD_TRACE_AGENT_HOSTNAME": "datadog-statsd.datadog",
     "DD_TRACE_AGENT_PORT": "8126",
     "LOGGLY_LEVEL": "info",
+    "MANAGER_TYPE": "K8S",
+    "PORT": 3010,
     "RATE_LIMIT_MAX": "100",
     "RATE_LIMIT_WINDOW_MS": "6000",
+    "SERVICE_NAME": "guardianship_agency",
     "TRACER": "datadog"
   },
   "local": {
-    "MAX_LOG_LENGTH": 5000,
-    "TRACER": "",
     "INDY_POOL_NAME": "pool1",
     "INDY_POOL_TRANSACTIONS_GENESIS_PATH": "./resources/pool_transactions_genesis_local_dev",
+    "INTERNAL_URL": "http://guardianship-agency:3010",
     "MANAGER_TYPE": "DOCKER",
+    "MAX_LOG_LENGTH": 5000,
     "PUBLIC_URL": "http://guardianship-agency:3010",
-    "INTERNAL_URL": "http://guardianship-agency:3010"
+    "TRACER": ""
   },
   "dev": {
     "DD_ENV": "protocol-dev",

--- a/src/config/env.json
+++ b/src/config/env.json
@@ -1,33 +1,47 @@
 {
   "default": {
+    "PORT": 3010,
+    "SERVICE_NAME": "guardianship_agency",
+    "MANAGER_TYPE": "K8S",
     "DD_AGENT_HOST": "datadog-statsd.datadog",
     "DD_TRACE_AGENT_HOSTNAME": "datadog-statsd.datadog",
     "DD_TRACE_AGENT_PORT": "8126",
     "LOGGLY_LEVEL": "info",
-    "PORT": 3010,
     "RATE_LIMIT_MAX": "100",
     "RATE_LIMIT_WINDOW_MS": "6000",
-    "SERVICE_NAME": "agency",
     "TRACER": "datadog"
   },
   "local": {
     "MAX_LOG_LENGTH": 5000,
-    "TRACER": ""
+    "TRACER": "",
+    "INDY_POOL_NAME": "pool1",
+    "INDY_POOL_TRANSACTIONS_GENESIS_PATH": "./resources/pool_transactions_genesis_local_dev",
+    "MANAGER_TYPE": "DOCKER",
+    "PUBLIC_URL": "http://guardianship-agency:3010",
+    "INTERNAL_URL": "http://guardianship-agency:3010"
   },
   "dev": {
     "DD_ENV": "protocol-dev",
-    "DD_TAGS": "env:protocol-dev"
+    "DD_TAGS": "env:protocol-dev",
+    "INDY_POOL_NAME": "KIVA_TEST",
+    "INDY_POOL_TRANSACTIONS_GENESIS_PATH": "/www/resources/pool_transactions_genesis_test_network"
   },
   "qa": {
     "DD_ENV": "protocol-qa",
-    "DD_TAGS": "env:protocol-qa"
+    "DD_TAGS": "env:protocol-qa",
+    "INDY_POOL_NAME": "KIVA_TEST",
+    "INDY_POOL_TRANSACTIONS_GENESIS_PATH": "/www/resources/pool_transactions_genesis_test_network"
   },
   "sand": {
     "DD_ENV": "protocol-sand",
-    "DD_TAGS": "env:protocol-sand"
+    "DD_TAGS": "env:protocol-sand",
+    "INDY_POOL_NAME": "KIVA_STAGING",
+    "INDY_POOL_TRANSACTIONS_GENESIS_PATH": "/www/resources/pool_transactions_genesis_staging"
   },
   "prod": {
     "DD_ENV": "protocol-prod",
-    "DD_TAGS": "env:protocol-prod"
+    "DD_TAGS": "env:protocol-prod",
+    "INDY_POOL_NAME": "KIVA_LIVE",
+    "INDY_POOL_TRANSACTIONS_GENESIS_PATH": "/www/resources/pool_transactions_genesis_live"
   }
 }

--- a/src/manager/agent.config.ts
+++ b/src/manager/agent.config.ts
@@ -1,0 +1,94 @@
+import {readFileSync} from 'fs';
+
+/**
+ * Centralizes the config setup for an agent so it can be used in docker or k8s
+ * TODO some of these things may need to be moved to env.json or .env files
+ */
+export class AgentConfig {
+
+    readonly inboundTransport: string;
+
+    readonly outboundTransport: string;
+
+    readonly ledgerPoolName: string;
+
+    readonly genesisTransactions: string;
+
+    readonly walletType: string;
+
+    readonly walletStorageType: string;
+
+    readonly walletName: string;
+
+    readonly walletKey: string;
+
+    readonly walletStorageConfig: string;
+
+    readonly walletStorageCreds: string;
+
+    readonly admin: string; // Admin url
+
+    readonly adminApiKey :string;
+
+    readonly label :string; // Agent name
+
+    readonly webhookUrl :string; // Controller endpoint
+
+    readonly endpoint: string; // Agent endpoint
+
+    readonly httpPort: string;
+
+    readonly adminPort: string;
+
+    /**
+     * Sets up the agent config
+     */
+    constructor(
+        walletId: string,
+        walletKey: string,
+        adminApiKey: string,
+        agentName: string,
+        agentEndpoint: string,
+        controllerEndpoint: string,
+        adminPort: string,
+        httpPort: string,
+    ) {
+        this.inboundTransport = `http 0.0.0.0 ${httpPort}`;
+        this.outboundTransport = 'http';
+        this.ledgerPoolName = process.env.INDY_POOL_NAME;
+        this.genesisTransactions = AgentConfig.getGenesisFile();
+        this.walletType = 'indy';
+        this.walletStorageType = 'postgres_storage';
+        this.walletName = walletId;
+        this.walletKey = walletKey;
+        this.walletStorageConfig = JSON.stringify(this.getWalletStorageConfig());
+        this.walletStorageCreds = JSON.stringify(this.getWalletStorageCreds());
+        this.admin = `0.0.0.0 ${adminPort}`;
+        this.adminApiKey = adminApiKey;
+        this.label = agentName;
+        this.webhookUrl = controllerEndpoint;
+        this.endpoint = agentEndpoint;
+        this.httpPort = httpPort;
+        this.adminPort = adminPort;
+    }
+
+    private getWalletStorageConfig() {
+        return {
+            url: process.env.WALLET_DB_HOST + ':' + process.env.WALLET_DB_PORT,
+            wallet_scheme: 'MultiWalletSingleTable',
+        };
+    }
+
+    private getWalletStorageCreds() {
+        return {
+            account: process.env.WALLET_DB_USER,
+            password: process.env.WALLET_DB_PASS,
+            admin_account: process.env.WALLET_DB_ADMIN_USER,
+            admin_password: process.env.WALLET_DB_ADMIN_PASS,
+        };
+    }
+
+    public static getGenesisFile(): string {
+        return readFileSync(process.env.INDY_POOL_TRANSACTIONS_GENESIS_PATH).toString();
+    }
+}

--- a/src/manager/agent.manager.interface.ts
+++ b/src/manager/agent.manager.interface.ts
@@ -1,16 +1,8 @@
+import { AgentConfig } from './agent.config';
 
 export interface IAgentManager {
 
-    startAgent(
-        walletId: string,
-        walletKey: string,
-        adminApiKey: string,
-        agentName: string,
-        agentEndpoint: string,
-        webhookUrl: string,
-        adminPort: string,
-        httpPort: string
-    ): Promise<string>;
+    startAgent(agentConfig: AgentConfig): Promise<string>;
 
     stopAgent(id: string): Promise<void>;
 }

--- a/src/manager/docker.service.ts
+++ b/src/manager/docker.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { Logger } from '@kiva/protocol-common/logger';
-import { ProtocolException } from '@kiva/protocol-common/protocol.exception';
 import Dockerode from 'dockerode';
 import { IAgentManager } from './agent.manager.interface';
+import { AgentConfig } from './agent.config';
 
 /**
  *
@@ -20,72 +19,45 @@ export class DockerService implements IAgentManager {
     }
 
     /**
-     * Start an agent with the given params
-     * TODO create an AgentConfig object will all these things specified, that way we don't have these crazy long signatures
+     * Start an agent with the given params using the expose docker api
      * TODO I don't think this handles errors properly if the agent fails to spin up
      */
-    public async startAgent(
-        walletId: string,
-        walletKey: string,
-        adminApiKey: string,
-        agentName: string,
-        agentEndpoint: string,
-        webhookUrl: string,
-        adminPort: string,
-        httpPort: string
-    ): Promise<string> {
-        // Putting const values here for now for simplicity:
-        // The ports shouldn't matter in production because they will only be localled to the container, but on our macs
-        // we want agents to have different ports so we can access them easier
-        const INDY_POOL_TRANSACTIONS_GENESIS_PATH = '/home/indy/resources/pool_transactions_genesis_local_dev';
-        const walletStorageConfig = {
-            url: process.env.WALLET_DB_HOST + ':' + process.env.WALLET_DB_PORT,
-            wallet_scheme: 'MultiWalletSingleTable',
-        };
-        const walletStorageCreds = {
-            account: process.env.WALLET_DB_USER,
-            password: process.env.WALLET_DB_PASS,
-            admin_account: process.env.WALLET_DB_ADMIN_USER,
-            admin_password: process.env.WALLET_DB_ADMIN_PASS,
-        };
-
+    public async startAgent(config: AgentConfig): Promise<string> {
+        const inboundTransportSplit = config.inboundTransport.split(' ');
+        const adminSplit = config.admin.split(' ');
         const container = await this.dockerode.createContainer({
             Image: 'bcgovimages/aries-cloudagent:py36-1.14-1_0.5.1', // TODO eventually we'll need a kiva image with our customizations
             Tty: true,
-            name: agentName,
+            name: config.label,
             ExposedPorts: {
-                [`${adminPort}/tcp`]: {},
-                [`${httpPort}/tcp`]: {}
+                [`${config.adminPort}/tcp`]: {},
+                [`${config.httpPort}/tcp`]: {}
             },
             HostConfig: {
                 AutoRemove: true,
                 NetworkMode: 'kiva-network',
-                Binds: [ // TODO instead of passing in the genesis file via volumes, we can do it over http which will make this less complex
-                    '/Users/jsaur/projects/protocol/experimental/agency/resources:/home/indy/resources/' // TODO how to do relative paths?
-                ],
                 PortBindings: {
-                    [`${adminPort}/tcp`]: [{ 'HostPort': adminPort}],
-                    [`${httpPort}/tcp`]: [{ 'HostPort': httpPort}]
+                    [`${config.adminPort}/tcp`]: [{ 'HostPort': config.adminPort}],
+                    [`${config.httpPort}/tcp`]: [{ 'HostPort': config.httpPort}]
                 }
             },
             Cmd: [
                 'start',
-                // Constant values
-                '--inbound-transport', 'http', '0.0.0.0', httpPort,
-                '--outbound-transport', 'http',
-                '--genesis-file', INDY_POOL_TRANSACTIONS_GENESIS_PATH,
-                '--wallet-type', 'indy',
-                '--wallet-storage-type', 'postgres_storage',
-                // Agent specific values
-                '--endpoint', agentEndpoint,
-                '--wallet-name', walletId,
-                '--wallet-key', walletKey,
-                '--wallet-storage-config', JSON.stringify(walletStorageConfig),
-                '--wallet-storage-creds', JSON.stringify(walletStorageCreds),
-                '--admin', '0.0.0.0', adminPort,
-                '--admin-api-key', adminApiKey,
-                '--label', agentName,
-                '--webhook-url', webhookUrl,
+                '--inbound-transport', inboundTransportSplit[0],  inboundTransportSplit[1], inboundTransportSplit[2],
+                '--outbound-transport', config.outboundTransport,
+                '--ledger-pool-name', config.ledgerPoolName,
+                '--genesis-transactions', config.genesisTransactions,
+                '--wallet-type', config.walletType,
+                '--wallet-storage-type', config.walletStorageType,
+                '--endpoint', config.endpoint,
+                '--wallet-name', config.walletName,
+                '--wallet-key', config.walletKey,
+                '--wallet-storage-config', config.walletStorageConfig,
+                '--wallet-storage-creds', config.walletStorageCreds,
+                '--admin', adminSplit[0], adminSplit[1],
+                '--admin-api-key', config.adminApiKey,
+                '--label', config.label,
+                '--webhook-url', config.webhookUrl,
                 // TODO For now we auto respond, eventually we will want more refined responses
                 '--log-level', 'debug',
                 '--auto-accept-invites',
@@ -98,18 +70,18 @@ export class DockerService implements IAgentManager {
         });
         await container.start();
         // Comment this in if we want to see docker logs here:
-        // await container.attach({stream: true, stdout: true, stderr: true}, (err, stream) => {
-        //     stream.pipe(process.stdout);
-        // });
+        container.attach({stream: true, stdout: true, stderr: true}, (err, stream) => {
+            stream.pipe(process.stdout);
+        });
         return container.id
     }
 
     /**
      * Stop agent by it's container id
+     * TODO it doesn't look like we need to call container.remove - but we should investigate the consequences
      */
     public async stopAgent(id: string): Promise<void> {
         const container = this.dockerode.getContainer(id);
         await container.stop();
-        // await container.remove(); // Looks like maybe we don't need to remove?
     }
 }

--- a/src/manager/k8s.service.ts
+++ b/src/manager/k8s.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { IAgentManager } from './agent.manager.interface';
+import { AgentConfig } from './agent.config';
+
+/**
+ * Starts and stops agents within a kubernetes environment
+ */
+@Injectable()
+export class K8sService implements IAgentManager {
+
+    /**
+     * TODO implement
+     */
+    public async startAgent(config: AgentConfig): Promise<string> {
+        throw new Error('Not implemented');
+    }
+
+    /**
+     * TODO implement
+     */
+    public async stopAgent(id: string): Promise<void> {
+        throw new Error('Not implemented');
+    }
+}


### PR DESCRIPTION
This cleans up my previous work to allow the agent manager to spin up agents in new docker containers. It introduces an AgentConfig to avoid duplication between docker and k8s. It also cleans up various things, like moving values into our config file, and passing in the genesis file directly as a string rather than trying to mount a volume.
I previously had this PR https://github.com/kiva/aries-guardianship-agency/pull/4 but I didn't do the signoff correctly, and because it involved some merge conflicts it was too hard to resolve so I just started a new PR here.
Signed-off-by: Jacob Saur <jsaur@kiva.org>