### PR TITLE
removing token from repo, adding comments about needing .npmrc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# so that this file isn't accidently checked in
+.npmrc
 # Logs
 logs
 *.log

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-//npm.pkg.github.com/:_authToken=2d44ddbc1825687c4c401ada22c0ba2501bf3166
-@kiva:registry=https://npm.pkg.github.com/kiva

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # aries-guardianship-agency
 
 For now you need to run the indy ledger and wallets db from the protocol repo
-You will als need to add your .env vars from another repo
+You will also need to add your .env vars from another repo
+You will also need to add .npmrc file to pull protocol-common package from kiva npm server.
 If you run into conflicts with docker images from another file run: docker rm -f $(docker ps -aq)
 To run the tests use: npm run test


### PR DESCRIPTION
Signed-off-by: Matt Raffel <mattr@kiva.org>

removing .npmrc from repo (this won't be needed once the package is public anyways)
adding comments about needing .npmrc file
added .npmrc to .gitignore (so that its not accidentally checked in)