### PR TITLE
Adds support ephemeral and permanent agent instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # so that this file isn't accidently checked in
 .npmrc
+.idea
 # Logs
 logs
 *.log

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, INestApplication } from '@nestjs/common';
+import { json } from 'body-parser';
+import { HttpConstants } from '@kiva/protocol-common/http-context/http.constants';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
@@ -25,7 +27,8 @@ export class AppService {
 
         const logger = new Logger(DatadogLogger.getLogger());
         app.useLogger(logger);
-
+        // Increase json parse size to handle encoded images
+        app.use(json({ limit: HttpConstants.JSON_LIMIT }));
         app.use(helmet());
 
         const corsWhitelist = process.env.CORS_WHITELIST;

--- a/src/manager/agent.manager.controller.ts
+++ b/src/manager/agent.manager.controller.ts
@@ -16,7 +16,7 @@ export class AgentManagerController {
      */
     @Post()
     public createAgent(@Body() body: any) {
-        return this.agentManagerService.spinUpAgent(body.walletId, body.walletKey, body.adminApiKey);
+        return this.agentManagerService.spinUpAgent(body.walletId, body.walletKey, body.adminApiKey, body.ttl);
     }
 
     /**

--- a/src/manager/agent.manager.service.ts
+++ b/src/manager/agent.manager.service.ts
@@ -53,8 +53,7 @@ export class AgentManagerService {
 
         const containerId = await this.manager.startAgent(agentConfig);
 
-        // when ttl is 0, record will stay in cache indefinitely
-        await this.cache.set(agentId, { containerId, adminPort, httpPort, adminApiKey, ttl });
+        await this.cache.set(agentId, { containerId, adminPort, httpPort, adminApiKey, ttl }, {ttl: 0});
 
         // ttl = time to live is expected to be in seconds (which we convert to milliseconds).  if 0, then live in eternity
         if (ttl > 0) {
@@ -72,6 +71,7 @@ export class AgentManagerService {
     public async spinDownAgent(agentId: string) {
         // TODO: do we need to remove this entry
         const agent: any = await this.cache.get(agentId);
+        await this.cache.del(agentId);
         Logger.log('Spinning down agent', agent);
         // TODO handle case were agent not there
         await this.manager.stopAgent(agent.containerId);

--- a/src/manager/agent.manager.service.ts
+++ b/src/manager/agent.manager.service.ts
@@ -12,7 +12,7 @@ import { K8sService } from './k8s.service';
 @Injectable()
 export class AgentManagerService {
 
-    private readonly DEFAULT_TTL_MS: number = 1000 * 60 * 5;
+    private readonly DEFAULT_TTL_MS: number = 5;
     private manager: IAgentManager;
 
     constructor(@Inject(CACHE_MANAGER) private readonly cache: CacheStore) {
@@ -33,7 +33,8 @@ export class AgentManagerService {
      * TODO need to handle error cases and ensure logging works in our deployed envs
      */
     public async spinUpAgent(walletId: string, walletKey: string, adminApiKey: string, ttl: number) {
-        ttl = ttl || this.DEFAULT_TTL_MS;
+        // 0 is a valid value in this case as it means service will run indefinitely
+        ttl = (ttl === undefined ? this.DEFAULT_TTL_MS : ttl);
 
         const agentId = cryptoRandomString({ length: 32, type: 'hex' });
         // TODO: could it be possible the same port is randomly generated?
@@ -54,12 +55,12 @@ export class AgentManagerService {
 
         await this.cache.set(agentId, { containerId, adminPort, httpPort, adminApiKey, ttl });
 
-        // ttl = time to live in milliseconds.  if 0, then live in eternity
+        // ttl = time to live is expected to be in seconds (which we convert to milliseconds).  if 0, then live in eternity
         if (ttl > 0) {
             setTimeout(
                 async () => {
                     await this.spinDownAgent(agentId);
-                }, ttl);
+                }, ttl * 1000);
         }
         return { agentId, containerId, adminPort, httpPort };
     }

--- a/src/manager/agent.manager.service.ts
+++ b/src/manager/agent.manager.service.ts
@@ -53,6 +53,7 @@ export class AgentManagerService {
 
         const containerId = await this.manager.startAgent(agentConfig);
 
+        // when ttl is 0, record will stay in cache indefinitely
         await this.cache.set(agentId, { containerId, adminPort, httpPort, adminApiKey, ttl });
 
         // ttl = time to live is expected to be in seconds (which we convert to milliseconds).  if 0, then live in eternity

--- a/src/manager/agent.manager.service.ts
+++ b/src/manager/agent.manager.service.ts
@@ -53,6 +53,8 @@ export class AgentManagerService {
 
         const containerId = await this.manager.startAgent(agentConfig);
 
+        // @tothink move this caching to db
+        // record lives in cache until it is explicitly deleted
         await this.cache.set(agentId, { containerId, adminPort, httpPort, adminApiKey, ttl }, {ttl: 0});
 
         // ttl = time to live is expected to be in seconds (which we convert to milliseconds).  if 0, then live in eternity
@@ -78,7 +80,7 @@ export class AgentManagerService {
     }
 
     /**
-     * TODO not sure if we'll keep this around because it doesn't guaruntee port overlaps, and also, ports are only really important when
+     * TODO not sure if we'll keep this around because it doesn't guarantee port overlaps, and also, ports are only really important when
      * testing on a mac. We deployed in k8s all agents can have the same ports and its file
      * Generates a random port between 5000-9999
      */

--- a/src/manager/agent.manager.service.ts
+++ b/src/manager/agent.manager.service.ts
@@ -53,7 +53,7 @@ export class AgentManagerService {
         const containerId = await this.manager.startAgent(agentConfig);
 
         // @tothink move this caching to db
-        // record lives in cache until it is explicitly deleted
+        // adding one second to cache record timeout so that spinDownAgent has time to process before cache deletes the record
         Logger.info(`record cache limit set to: ${(ttl === 0 ? ttl : ttl + 1000)}}`);
         await this.cache.set(agentId, { containerId, adminPort, httpPort, adminApiKey, ttl }, {ttl: (ttl === 0 ? ttl : ttl + 1000)});
         // ttl = time to live is expected to be in seconds (which we convert to milliseconds).  if 0, then live in eternity


### PR DESCRIPTION
Adds another parameter to AgentMananger API to include time to live value for an agent.  Value is the milliseconds the agent will remain running.  Default is 5 mins.  0 means permanently.

Signed-off-by: Matt Raffel <mattr@kiva.org>