### PR TITLE
Add support for custom seeds, controller urls, and aliases

### DIFF
--- a/src/manager/agent.config.ts
+++ b/src/manager/agent.config.ts
@@ -40,6 +40,8 @@ export class AgentConfig {
 
     readonly adminPort: string;
 
+    readonly seed: string;
+
     /**
      * Sets up the agent config
      */
@@ -49,9 +51,10 @@ export class AgentConfig {
         adminApiKey: string,
         agentName: string,
         agentEndpoint: string,
-        controllerEndpoint: string,
+        webhookUrl: string,
         adminPort: string,
         httpPort: string,
+        seed?: string,
     ) {
         this.inboundTransport = `http 0.0.0.0 ${httpPort}`;
         this.outboundTransport = 'http';
@@ -66,10 +69,11 @@ export class AgentConfig {
         this.admin = `0.0.0.0 ${adminPort}`;
         this.adminApiKey = adminApiKey;
         this.label = agentName;
-        this.webhookUrl = controllerEndpoint;
+        this.webhookUrl = webhookUrl;
         this.endpoint = agentEndpoint;
         this.httpPort = httpPort;
         this.adminPort = adminPort;
+        this.seed = seed;
     }
 
     private getWalletStorageConfig() {

--- a/src/manager/agent.manager.controller.ts
+++ b/src/manager/agent.manager.controller.ts
@@ -13,10 +13,11 @@ export class AgentManagerController {
 
     /**
      * TODO use the DTOs from the agency folder
+     * TODO ignoring the linting errors for now, need to fix eventually - perhaps by passing the full DTO object
      */
     @Post()
     public createAgent(@Body() body: any) {
-        return this.agentManagerService.spinUpAgent(body.walletId, body.walletKey, body.adminApiKey, body.ttl);
+        return this.agentManagerService.spinUpAgent(body.walletId, body.walletKey, body.adminApiKey, body.ttl, body.seed, body.controllerUrl, body.alias);
     }
 
     /**


### PR DESCRIPTION
This adds some more custom params to the agent manager so we can specify a seed controller url and alias. Also I found that setting the cache to 0 didn't work (it caches for 0 seconds not for infinity) so added some comments.
Signed-off-by: Jacob Saur <jsaur@kiva.org>