### PR TITLE
updates connection handler to respond by calling accept-request for citizen agent when state is request

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you have access to other protocol repos, you can get the values from those re
   
 Note the very first time you run this you need to ensure you have the latest aca py image in your docker cache  
 
-Check src/config/env.json for the most up to date version:
+Check `src/config/env.json` for the most up to date version:
 ```
  docker pull bcgovimages/aries-cloudagent:py36-1.15-0_0.5.2
 ```
@@ -65,7 +65,7 @@ If you want to connect to the kiva-network from the protocol-repo you need to up
   NETWORK_NAME=kiva-network
 You can then run
 ```
-npm run install
+npm install
 docker-compose -f docker-compose.kiva-network.yml
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you have access to other protocol repos, you can get the values from those re
   
 Note the very first time you run this you need to ensure you have the latest aca py image in your docker cache  
 
-Check `src/config/env.json` for the most up to date version:
+# Check `src/config/env.json` for the most up to date version:
 ```
  docker pull bcgovimages/aries-cloudagent:py36-1.15-0_0.5.2
 ```

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 You will need to add your .env vars from another repo (TODO figure out a good way to pass those .env vars in)  
 Note the very first time you run this you need to ensure you have the latest aca py image in your docker cache  
 
-Check /config/env.json for the most up to date version:
+Check src/config/env.json for the most up to date version:
 ```
  docker pull bcgovimages/aries-cloudagent:py36-1.15-0_0.5.2
 ```
 The main docker-compose will spin up the agency, a local indy ledger, and a postgres wallets db to connect to:
 ```
-npm run install
+npm install
 docker-compose up
 ```
 To run tests:
@@ -25,6 +25,13 @@ POST http://localhost:3010/v1/manager
 	"walletId": "walletId001",
 	"walletKey": "walletKey001",
 	"adminApiKey": "adminApiKey"
+	"walletId": "walletId",
+	"walletKey": "walletkey",
+	"adminApiKey": "someAdminKey",
+	"ttl": -1,
+	"seed": "000000000000000000000000ABCDEFG1",
+	"controllerUrl": "http://controller:1010",
+	"alias": "testAgent2"
 }
 ```
 To spin down the agent, use the returned agentId from above and do:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ POST http://localhost:3010/v1/manager
 	"adminApiKey": "someAdminKey",
 	"ttl": -1,
 	"seed": "000000000000000000000000ABCDEFG1",
-	"controllerUrl": "http://controller:1010",
 	"alias": "testAgent2"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
 # Aries Guardianship Agency
 
 ### Setup
-You will need to add your .env vars from another repo (TODO figure out a good way to pass those .env vars in)  
+You will need to following variables in the .env file.  Values are not literal, this just an example:
+```
+# ENV FILE FOR AGENCY
+NODE_ENV=LOCAL
+
+# For Wallet DB
+WALLET_DB_HOST=hostname
+WALLET_DB_PORT=5432
+WALLET_DB_USER=username
+WALLET_DB_PASS=password
+WALLET_DB_ADMIN_USER=adminusername
+WALLET_DB_ADMIN_PASS=password
+POSTGRES_PASSWORD=password
+```
+If you have access to other protocol repos, you can get the values from those repos.
+
+(TODO figure out a good way to pass those .env vars in)  
+  
 Note the very first time you run this you need to ensure you have the latest aca py image in your docker cache  
 
 Check src/config/env.json for the most up to date version:

--- a/src/config/governence.json
+++ b/src/config/governence.json
@@ -6,18 +6,44 @@
   },
   "permissive": {
     "connections": {
-      "invitation": "always",
-      "request": "always"
+      "create-invitation": "always",
+      "receive-invitation": "always",
+      "accept-invitation": "always",
+      "accept-request": "always",
+      "send-ping": "always",
+      "remove": "always"
+    },
+    "proof": {
+      "proposal_sent": "always",
+      "proposal_received": "always",
+      "offer_sent": "always",
+      "offer_received": "always",
+      "request_sent": "always",
+      "request_received": "always",
+      "credential_issued": "always",
+      "credential_received": "always",
+      "credential_acked": "always"
     }
   },
   "SierraLeone": {
     "connections": {
-      "invitation": "once",
-      "request": "always"
+      "create-invitation": "once",
+      "receive-invitation": "always",
+      "accept-invitation": "always",
+      "accept-request": "always",
+      "send-ping": "always",
+      "remove": "always"
     },
-    "create-proof": {
-      "invitation": "once",
-      "request": "always"
+    "proof": {
+      "proposal_sent": "once",
+      "proposal_received": "once",
+      "offer_sent": "once",
+      "offer_received": "once",
+      "request_sent": "always",
+      "request_received": "always",
+      "credential_issued": "once",
+      "credential_received": "once",
+      "credential_acked": "always"
     }
   }
 }

--- a/src/config/governence.json
+++ b/src/config/governence.json
@@ -6,44 +6,12 @@
   },
   "permissive": {
     "connections": {
-      "create-invitation": "always",
-      "receive-invitation": "always",
-      "accept-invitation": "always",
-      "accept-request": "always",
-      "send-ping": "always",
-      "remove": "always"
-    },
-    "proof": {
-      "proposal_sent": "always",
-      "proposal_received": "always",
-      "offer_sent": "always",
-      "offer_received": "always",
-      "request_sent": "always",
-      "request_received": "always",
-      "credential_issued": "always",
-      "credential_received": "always",
-      "credential_acked": "always"
+      "accept-invitation": "always"
     }
   },
-  "SierraLeone": {
+  "SingleConnection": {
     "connections": {
-      "create-invitation": "once",
-      "receive-invitation": "always",
-      "accept-invitation": "always",
-      "accept-request": "always",
-      "send-ping": "always",
-      "remove": "always"
-    },
-    "proof": {
-      "proposal_sent": "once",
-      "proposal_received": "once",
-      "offer_sent": "once",
-      "offer_received": "once",
-      "request_sent": "always",
-      "request_received": "always",
-      "credential_issued": "once",
-      "credential_received": "once",
-      "credential_acked": "always"
+      "accept-invitation": "once"
     }
   }
 }

--- a/src/controller/agent.controller.service.ts
+++ b/src/controller/agent.controller.service.ts
@@ -7,6 +7,8 @@ import { AgentGovernance } from './agent.governance';
 import { HandlersFactory } from './handler/handlers.factory';
 
 /**
+ * Agent acting on the behalf of a "citizen"
+ *
  * TODO this needs to handle general requests that come from the agents for the controller to handle -
  * it should have some way of checking what it's behavior should be and respond accordingly
  */
@@ -24,20 +26,10 @@ export class AgentControllerService {
     }
 
     async handleRequest(agentId: string, route: string, topic: string, body: any) {
-        if (AgentGovernance.PERMISSION_DENY === this.agentGovernance.getPermission(route, topic)) {
-            throw new ProtocolException('AgencyGovernance',`${topic} governance doesnt not allow.`);
-        }
-
+        Logger.info(`AgentControllerService.handleRequest(${agentId}, ${route}, ${topic})`, body);
         const agent: any = await this.cache.get(agentId);
         const agentUrl = `http://${agentId}:${agent.adminPort}`;
 
         return HandlersFactory.getHandler(this.agentGovernance, topic).handlePost(agentUrl, agent.adminApiKey, route, topic, body);
-    }
-
-    /**
-     * Test function in case we want to slow things down
-     */
-    delay(ms: number) {
-        return new Promise( resolve => setTimeout(resolve, ms) );
     }
 }

--- a/src/controller/agent.controller.service.ts
+++ b/src/controller/agent.controller.service.ts
@@ -3,7 +3,8 @@ import { ProtocolHttpService } from 'protocol-common/protocol.http.service';
 import { AxiosRequestConfig } from 'axios';
 import { ProtocolException } from 'protocol-common/protocol.exception';
 import { Logger } from 'protocol-common/logger';
-import {AgentGovernance} from './agent.governance';
+import { AgentGovernance } from './agent.governance';
+import { HandlersFactory } from './handler/handlers.factory';
 
 /**
  * TODO this needs to handle general requests that come from the agents for the controller to handle -
@@ -23,65 +24,14 @@ export class AgentControllerService {
     }
 
     async handleRequest(agentId: string, route: string, topic: string, body: any) {
-        // For now let's not do anything
-        return 'success';
-
-        // TODO leaving some of this code around - eventually we probably want a way to custom respond to each request
+        if (AgentGovernance.PERMISSION_DENY === this.agentGovernance.getPermission(route, topic)) {
+            throw new ProtocolException('AgencyGovernance',`${topic} governance doesnt not allow.`);
+        }
 
         const agent: any = await this.cache.get(agentId);
         const agentUrl = `http://${agentId}:${agent.adminPort}`;
-        let req: AxiosRequestConfig;
-        // Ad hoc throwing in custom logic, TODO move this to separate handler functions for each topic
-        if (topic === 'connections') {
-            if (body.initiator === 'self') {
-                Logger.log('self initiated request, nothing to handle');
-                return;
-            }
 
-            // If this is an external invitation then accept-invitation
-            // TODO: add in policy check. eg:
-            //     const action = this.agentGovernance.getPermission(topic, body.state)
-            //     if (action === 'deny') throw new Error('denied!');
-            // TODO: clean up if/else with switch
-            if (body.state === 'invitation') {
-                Logger.log('...processing invitation')
-                req = {
-                    method: 'POST',
-                    url: agentUrl + `/connections/${body.connection_id}/accept-invitation`,
-                    headers: {
-                        'x-api-key': agent.adminApiKey,
-                    }
-                };
-            } else if (body.state === 'request') {
-                Logger.log('...processing request')
-                req = {
-                    method: 'POST',
-                    url: agentUrl + `/connections/${body.connection_id}/accept-request`,
-                    headers: {
-                        'x-api-key': agent.adminApiKey,
-                    }
-                };
-            } else if (body.state === 'response') {
-                // Sending a ping to show-case the connection worked
-                Logger.log('...processing response')
-                req = {
-                    method: 'POST',
-                    url: agentUrl + `/connections/${body.connection_id}/send-ping`,
-                    headers: {
-                        'x-api-key': agent.adminApiKey,
-                    },
-                    data: {
-                        comment: 'Test connection'
-                    }
-                };
-
-            } else {
-                throw new ProtocolException('Unknown', `Unknown state for 'connection' ${body.state}`);
-            }
-            Logger.log(`...calling ${req.url}`);
-            const res = await this.http.requestWithRetry(req);
-            return 'success'; // TODO should we just return success? or something else?
-        }
+        return HandlersFactory.getHandler(this.agentGovernance, topic).handlePost(agentUrl, agent.adminApiKey, route, topic, body);
     }
 
     /**

--- a/src/controller/agent.controller.service.ts
+++ b/src/controller/agent.controller.service.ts
@@ -30,6 +30,6 @@ export class AgentControllerService {
         const agent: any = await this.cache.get(agentId);
         const agentUrl = `http://${agentId}:${agent.adminPort}`;
 
-        return HandlersFactory.getHandler(this.agentGovernance, topic).handlePost(agentUrl, agent.adminApiKey, route, topic, body);
+        return HandlersFactory.getHandler(this.agentGovernance, topic, this.cache).handlePost(agentUrl, agent.adminApiKey, route, topic, body);
     }
 }

--- a/src/controller/agent.controller.service.ts
+++ b/src/controller/agent.controller.service.ts
@@ -7,10 +7,8 @@ import { AgentGovernance } from './agent.governance';
 import { HandlersFactory } from './handler/handlers.factory';
 
 /**
- * Agent acting on the behalf of a "citizen"
+ * Agent acting on the behalf of a "citizen" or credential holder
  *
- * TODO this needs to handle general requests that come from the agents for the controller to handle -
- * it should have some way of checking what it's behavior should be and respond accordingly
  */
 @Injectable()
 export class AgentControllerService {
@@ -28,6 +26,7 @@ export class AgentControllerService {
     async handleRequest(agentId: string, route: string, topic: string, body: any) {
         Logger.info(`AgentControllerService.handleRequest(${agentId}, ${route}, ${topic})`, body);
         const agent: any = await this.cache.get(agentId);
+        // @tothink http/https?  should this be from the env?
         const agentUrl = `http://${agentId}:${agent.adminPort}`;
 
         return HandlersFactory.getHandler(this.agentGovernance, topic, this.cache).handlePost(agentUrl, agent.adminApiKey, route, topic, body);

--- a/src/controller/agent.governance.ts
+++ b/src/controller/agent.governance.ts
@@ -8,9 +8,9 @@ import data from '../config/governence.json';
 @Injectable()
 export class AgentGovernance {
     // see GOVERANCE.md for documentation on policies data structure
-    private static PERMISSION_DENY = 'deny';
-    private static PERMISSION_ONCE = 'once';
-    private static PERMISSION_ALWAYS = 'always';
+    public static PERMISSION_DENY = 'deny';
+    public static PERMISSION_ONCE = 'once';
+    public static PERMISSION_ALWAYS = 'always';
     private static ALL_KEY = 'all';
     private static COMMENT_SECTION = 'comment';
     private readonly policies = { };

--- a/src/controller/handler/agent.response.handler.ts
+++ b/src/controller/handler/agent.response.handler.ts
@@ -1,0 +1,6 @@
+
+export interface IAgentResponseHandler {
+    // For passing on GET API calls into ACAPY
+    handleGet(agentUrl: string, adminApiKey: string, route: string, topic: string): Promise<any>;
+    handlePost(agentUrl: string, adminApiKey: string, route: string, topic: string, body: any): Promise<any>;
+}

--- a/src/controller/handler/agent.response.handler.ts
+++ b/src/controller/handler/agent.response.handler.ts
@@ -1,6 +1,7 @@
 
+/*
+   Defines required contract for classes implementing webhook handlers
+ */
 export interface IAgentResponseHandler {
-    // For passing on GET API calls into ACAPY
-    handleGet(agentUrl: string, adminApiKey: string, route: string, topic: string): Promise<any>;
     handlePost(agentUrl: string, adminApiKey: string, route: string, topic: string, body: any): Promise<any>;
 }

--- a/src/controller/handler/connections.ts
+++ b/src/controller/handler/connections.ts
@@ -1,0 +1,70 @@
+import { AxiosRequestConfig } from 'axios';
+import { Logger } from 'protocol-common/logger';
+import { NotImplementedException } from "@nestjs/common";
+import { ProtocolHttpService } from 'protocol-common/protocol.http.service';
+import { IAgentResponseHandler } from './agent.response.handler';
+import { AgentGovernance } from '../agent.governance';
+
+export class Connections implements IAgentResponseHandler {
+    private static CONNECTIONS_URL: string = 'connections';
+    private readonly http: ProtocolHttpService;
+    constructor(private readonly agentGovernance: AgentGovernance) {
+    }
+
+    public async handleGet(agentUrl: string, adminApiKey: string, route: string, topic: string): Promise<any> {
+        throw new NotImplementedException();
+    }
+
+    /*
+       body is expected to be like this
+       {
+           "routing_state":"none",
+           "their_label":"Aries Cloud Agent",
+           "alias":"For-Meditor",
+           "my_did":"Yad6847oyTWq7du8qeEFe9",
+           "accept":"manual",
+           "updated_at":"2020-07-16 14:36:45.759114Z",
+           "created_at":"2020-07-16 14:36:01.286531Z",
+           "invitation_key":"62zG2GJEKuY5BTRLjAt9U5YFWchJex2KnDPSf7D92adT",
+           "connection_id":"ddbf57a4-e801-4f70-b508-a91383155476",
+           "request_id":"d898835e-9b3d-4cca-be70-724a0b1a083a",
+           "state":"request",
+           "initiator":"external",
+           "invitation_mode":"once"
+        }
+
+        for this handler, this will always be true:
+        Route will be "topic"
+        topic will be "connections"
+    */
+    public async handlePost(agentUrl: string, adminApiKey: string, route: string, topic: string, body: any): Promise<any> {
+
+        /*
+            TODO: to accept an invitation, some other process will do these steps
+                1 - get a connection invitation
+                2 - pass invitation to second agent
+             From there, we can
+                1 - tell one agent to accept (trick is which one)
+                2 - then tell the other agent to accept
+
+         */
+
+        Logger.log(`...processing ${body.state}`, body);
+
+        let url: string = agentUrl + `/${Connections.CONNECTIONS_URL}/`;
+
+        const req: AxiosRequestConfig = {
+            method: 'POST',
+            url,
+            headers: {
+                'x-api-key': adminApiKey,
+            },
+            data: body.message
+        };
+
+        Logger.log(`...calling ${req.url}`);
+        const res = await this.http.requestWithRetry(req);
+        // have to return actual API results so that client can process it
+        return res;
+    }
+}

--- a/src/controller/handler/connections.ts
+++ b/src/controller/handler/connections.ts
@@ -47,7 +47,7 @@ export class Connections implements IAgentResponseHandler {
             return;
         }
 
-        if (AgentGovernance.PERMISSION_DENY === this.agentGovernance.getPermission(route, topic)) {
+        if (AgentGovernance.PERMISSION_DENY === this.agentGovernance.getPermission("connections", "accept-invitation")) {
             throw new ProtocolException('AgencyGovernance',`${topic} governance doesnt not allow.`);
         }
 

--- a/src/controller/handler/handlers.factory.ts
+++ b/src/controller/handler/handlers.factory.ts
@@ -3,6 +3,7 @@ import { IAgentResponseHandler } from './agent.response.handler';
 import { Connections } from './connections';
 import { AgentGovernance } from '../agent.governance';
 import { Proofs } from './proof';
+import {CacheStore} from "@nestjs/common";
 
 /*
     @TODO we want to replace this factory with nestjs injection at some point
@@ -11,12 +12,12 @@ export class HandlersFactory {
     /*
 
      */
-    public static getHandler(agentGovernance: AgentGovernance, topic: string): IAgentResponseHandler {
+    public static getHandler(agentGovernance: AgentGovernance, topic: string, cache: CacheStore): IAgentResponseHandler {
         switch (topic) {
             case 'connections':
-                return new Connections(agentGovernance);
+                return new Connections(agentGovernance, cache);
             case 'proofs':
-                return new Proofs(agentGovernance);
+                return new Proofs(agentGovernance, cache);
             default:
                 break;
         }

--- a/src/controller/handler/handlers.factory.ts
+++ b/src/controller/handler/handlers.factory.ts
@@ -1,0 +1,25 @@
+import { ProtocolException } from 'protocol-common/protocol.exception';
+import { IAgentResponseHandler } from './agent.response.handler';
+import { Connections } from './connections';
+import { AgentGovernance } from '../agent.governance';
+import { Proofs } from './proof';
+
+/*
+    @TODO we want to replace this factory with nestjs injection at some point
+ */
+export class HandlersFactory {
+    /*
+
+     */
+    public static getHandler(agentGovernance: AgentGovernance, topic: string): IAgentResponseHandler {
+        switch (topic) {
+            case 'connections':
+                return new Connections(agentGovernance);
+            case 'proofs':
+                return new Proofs(agentGovernance);
+            default:
+                break;
+        }
+        throw new ProtocolException('Agency', 'No suitable handler found for topic');
+    }
+}

--- a/src/controller/handler/proof.ts
+++ b/src/controller/handler/proof.ts
@@ -1,0 +1,67 @@
+import { NotImplementedException } from '@nestjs/common';
+import { ProtocolHttpService } from 'protocol-common/protocol.http.service';
+import { Logger } from 'protocol-common/logger';
+import { ProtocolException } from 'protocol-common/protocol.exception';
+import { IAgentResponseHandler } from './agent.response.handler';
+import { AgentGovernance } from '../agent.governance';
+import {AxiosRequestConfig} from "axios";
+
+export class Proofs implements IAgentResponseHandler {
+    private static PROOFS_URL: string = 'proofs';
+    private readonly http: ProtocolHttpService;
+
+    constructor(private readonly agentGovernance: AgentGovernance) {
+    }
+
+    public async handleGet(agentUrl: string, adminApiKey: string, route: string, topic: string): Promise<any> {
+        throw new NotImplementedException();
+    }
+
+    /*
+        body json object, two requirements
+           message: json object, must match Aries ACAPY inputs for given call
+
+       TODO: would be nice if consumer didn't need to know how to format messages for Aries ACAPY
+     */
+    public async handlePost(agentUrl: string, adminApiKey: string, route: string, topic: string, body: any): Promise<any> {
+        if (body.initiator === 'self') {
+            Logger.log('self initiated request, nothing to handle');
+            return;
+        }
+
+        let finalRoute: string = '';
+        let url: string = agentUrl + `/${Proofs.PROOFS_URL}`;
+        // for documnetation purposes the following were referenced:
+        // acapy/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
+        // and  acapy/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
+        // and  acapy/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
+        switch (topic) {
+            case 'proposal_sent':
+            case 'proposal_received':
+            case 'offer_sent':
+            case 'offer_received':
+            case 'request_sent':
+            case 'request_received':
+            case 'credential_issued':
+            case 'credential_received':
+            case 'credential_acked':
+            default:
+                throw new ProtocolException('Unknown', `Unknown topic for 'proof' ${topic}`);
+                break;
+        }
+
+        // url: string = agentUrl + `/${Proofs.PROOFS_URL}/${body.connection_id}/${finalRoute}`;
+        const req: AxiosRequestConfig = {
+            method: 'POST',
+            url,
+            headers: {
+                'x-api-key': adminApiKey,
+            },
+            data: body.message
+        };
+
+        Logger.log(`...calling ${req.url}`);
+        const res = await this.http.requestWithRetry(req);
+        return 'success'; // TODO should we just return success? or something else?
+    }
+}

--- a/src/controller/handler/proof.ts
+++ b/src/controller/handler/proof.ts
@@ -1,4 +1,4 @@
-import { NotImplementedException } from '@nestjs/common';
+import {CacheStore, NotImplementedException} from '@nestjs/common';
 import { ProtocolHttpService } from 'protocol-common/protocol.http.service';
 import { Logger } from 'protocol-common/logger';
 import { ProtocolException } from 'protocol-common/protocol.exception';
@@ -10,7 +10,7 @@ export class Proofs implements IAgentResponseHandler {
     private static PROOFS_URL: string = 'proofs';
     private readonly http: ProtocolHttpService;
 
-    constructor(private readonly agentGovernance: AgentGovernance) {
+    constructor(private readonly agentGovernance: AgentGovernance, private readonly cache: CacheStore) {
     }
 
     public async handleGet(agentUrl: string, adminApiKey: string, route: string, topic: string): Promise<any> {
@@ -18,50 +18,28 @@ export class Proofs implements IAgentResponseHandler {
     }
 
     /*
-        body json object, two requirements
-           message: json object, must match Aries ACAPY inputs for given call
+       body is expected to be like this
+       {
+           "routing_state":"none",
+           "their_label":"Aries Cloud Agent",
+           "alias":"For-Meditor",
+           "my_did":"Yad6847oyTWq7du8qeEFe9",
+           "accept":"manual",
+           "updated_at":"2020-07-16 14:36:45.759114Z",
+           "created_at":"2020-07-16 14:36:01.286531Z",
+           "invitation_key":"62zG2GJEKuY5BTRLjAt9U5YFWchJex2KnDPSf7D92adT",
+           "connection_id":"ddbf57a4-e801-4f70-b508-a91383155476",
+           "request_id":"d898835e-9b3d-4cca-be70-724a0b1a083a",
+           "state":"request",
+           "initiator":"external",
+           "invitation_mode":"once"
+        }
 
-       TODO: would be nice if consumer didn't need to know how to format messages for Aries ACAPY
+        for this handler, this will always be true:
+        Route will be "topic"
+        topic will be "????"
      */
     public async handlePost(agentUrl: string, adminApiKey: string, route: string, topic: string, body: any): Promise<any> {
-        if (body.initiator === 'self') {
-            Logger.log('self initiated request, nothing to handle');
-            return;
-        }
-
-        let finalRoute: string = '';
-        let url: string = agentUrl + `/${Proofs.PROOFS_URL}`;
-        // for documnetation purposes the following were referenced:
-        // acapy/aries_cloudagent/protocols/issue_credential/v1_0/models/credential_exchange.py
-        // and  acapy/aries_cloudagent/protocols/issue_credential/v1_0/manager.py
-        // and  acapy/aries_cloudagent/protocols/issue_credential/v1_0/routes.py
-        switch (topic) {
-            case 'proposal_sent':
-            case 'proposal_received':
-            case 'offer_sent':
-            case 'offer_received':
-            case 'request_sent':
-            case 'request_received':
-            case 'credential_issued':
-            case 'credential_received':
-            case 'credential_acked':
-            default:
-                throw new ProtocolException('Unknown', `Unknown topic for 'proof' ${topic}`);
-                break;
-        }
-
-        // url: string = agentUrl + `/${Proofs.PROOFS_URL}/${body.connection_id}/${finalRoute}`;
-        const req: AxiosRequestConfig = {
-            method: 'POST',
-            url,
-            headers: {
-                'x-api-key': adminApiKey,
-            },
-            data: body.message
-        };
-
-        Logger.log(`...calling ${req.url}`);
-        const res = await this.http.requestWithRetry(req);
         return 'success'; // TODO should we just return success? or something else?
     }
 }


### PR DESCRIPTION
What issue is this targeting?
Acapy agents are spun up with  --auto-accept-invites and --auto-accept-requests turned off which means agents will never finish the acceptance of a connection invite.

Changes proposed in this pull request
Adding a handler to tell citizen agents to accept an invite once the connection invitation status is at 'request' state.

🚀 Deployment changes 🚀
(list added or removed env, db changes etc)

Other Notes