### PR TITLE
auto connect to agent updates

### DIFF
--- a/src/manager/agent.manager.controller.ts
+++ b/src/manager/agent.manager.controller.ts
@@ -17,7 +17,7 @@ export class AgentManagerController {
      */
     @Post()
     public createAgent(@Body() body: any) {
-        return this.agentManagerService.spinUpAgent(body.walletId, body.walletKey, body.adminApiKey, body.ttl, body.seed, body.controllerUrl, body.alias);
+        return this.agentManagerService.spinUpAgent(body.walletId, body.walletKey, body.adminApiKey, body.ttl, body.seed, body.controllerUrl, body.alias, body.autoConnect);
     }
 
     /**

--- a/src/manager/agent.manager.service.ts
+++ b/src/manager/agent.manager.service.ts
@@ -197,6 +197,10 @@ export class AgentManagerService {
                     connectionData
                 };
             }
+            if (agentData && autoConnect === false) {
+                return agentData;
+            }
+
         }
         return null;
     }

--- a/src/manager/agent.manager.service.ts
+++ b/src/manager/agent.manager.service.ts
@@ -33,7 +33,7 @@ export class AgentManagerService {
      * TODO need to think through a few more cases - like how the public endpoints and ports will work
      * TODO need to handle error cases and ensure logging works in our deployed envs
      */
-    public async spinUpAgent(walletId: string, walletKey: string, adminApiKey: string, ttl?: number, seed?: string, controllerUrl?: string, alias?: string) {
+    public async spinUpAgent(walletId: string, walletKey: string, adminApiKey: string, ttl?: number, seed?: string, controllerUrl?: string, alias?: string, autoConnect?: boolean) {
         const runningData = await this.handleAlreadyRunningContainer(alias, adminApiKey);
         if (runningData) {
             return runningData;
@@ -73,10 +73,14 @@ export class AgentManagerService {
                 }, ttl * 1000);
         }
 
-        // TODO for right now let's delay and then inititate the connection
-        // TODO this functionality should be optional based on passed in params
-        await this.delay(8000);
-        const connectionData = await this.createConnection(agentId, adminPort, adminApiKey);
+        let connectionData = {};
+        // when autoConnect is true, then call the createConnection method
+        // when autoCorrect is not defined, treat it as true
+        if (!autoConnect || autoConnect === true) {
+            // TODO for right now let's delay and then initiate the connection
+            await this.delay(8000);
+            connectionData = await this.createConnection(agentId, adminPort, adminApiKey);
+        }
 
         return { agentId, containerId, adminPort, httpPort, connectionData };
     }

--- a/src/manager/agent.manager.service.ts
+++ b/src/manager/agent.manager.service.ts
@@ -33,7 +33,7 @@ export class AgentManagerService {
      * TODO need to think through a few more cases - like how the public endpoints and ports will work
      * TODO need to handle error cases and ensure logging works in our deployed envs
      */
-    public async spinUpAgent(walletId: string, walletKey: string, adminApiKey: string, ttl?: number, seed?: string, controllerUrl?: string, alias?: string, autoConnect?: boolean) {
+    public async spinUpAgent(walletId: string, walletKey: string, adminApiKey: string, ttl?: number, seed?: string, controllerUrl?: string, alias?: string, autoConnect: boolean = true) {
         const runningData = await this.handleAlreadyRunningContainer(alias, adminApiKey);
         if (runningData) {
             return runningData;
@@ -75,8 +75,8 @@ export class AgentManagerService {
 
         let connectionData = {};
         // when autoConnect is true, then call the createConnection method
-        // when autoCorrect is not defined, treat it as true
-        if (!autoConnect || autoConnect === true) {
+        // when autoCorrect is not defined or null, treat it as true
+        if (autoConnect === true) {
             // TODO for right now let's delay and then initiate the connection
             await this.delay(8000);
             connectionData = await this.createConnection(agentId, adminPort, adminApiKey);

--- a/src/manager/docker.service.ts
+++ b/src/manager/docker.service.ts
@@ -79,7 +79,10 @@ export class DockerService implements IAgentManager {
         await container.start();
         // Comment this in if we want to see docker logs here:
         container.attach({stream: true, stdout: true, stderr: true}, (err, stream) => {
-            stream.pipe(process.stdout);
+            // stream.pipe(process.stdout);
+            stream.on('data', (chunk: Buffer) => {
+                Logger.log(`we got stuff [${chunk.length}] '${chunk.toString()}'`);
+            })
         });
         return container.id
     }

--- a/src/manager/docker.service.ts
+++ b/src/manager/docker.service.ts
@@ -79,10 +79,7 @@ export class DockerService implements IAgentManager {
         await container.start();
         // Comment this in if we want to see docker logs here:
         container.attach({stream: true, stdout: true, stderr: true}, (err, stream) => {
-            // stream.pipe(process.stdout);
-            stream.on('data', (chunk: Buffer) => {
-                Logger.log(`we got stuff [${chunk.length}] '${chunk.toString()}'`);
-            })
+            stream.pipe(process.stdout);
         });
         return container.id
     }


### PR DESCRIPTION
Signed-off-by: Matt Raffel <mattr@kiva.org>

1) API call allows for controlling if auto connect to agent is needed.  Parameter autoConnect = true.   It must be explicitly set to false to not auto connect.
2) replaced hard coded delay with a more intelligent loop that attempts to ping the agent to see if its up and responding