### PR TITLE
Use request instead of requestWithRetry and handle errors

### DIFF
--- a/src/manager/agent.manager.service.ts
+++ b/src/manager/agent.manager.service.ts
@@ -176,7 +176,6 @@ export class AgentManagerService {
             } catch (e) {
                 // Do nothing and try again
             }
-            await this.delay(1000);
             Logger.info(`pingConnectionWithRetry is retrying`);
         }
 

--- a/src/manager/agent.manager.service.ts
+++ b/src/manager/agent.manager.service.ts
@@ -146,7 +146,9 @@ export class AgentManagerService {
             return result;
         };
 
-        const http = new ProtocolHttpService(new HttpService());
+        // TODO we should either add a non-retry call to ProtocolHttpService, or make the existing requestWithRetry more configurable to be used here
+        // const http = new ProtocolHttpService(new HttpService());
+        const http = new HttpService();
         const url = `http://${agentId}:${adminPort}/status`;
         Logger.info(`agent admin url is ${url}`);
         const req: any = {
@@ -164,7 +166,12 @@ export class AgentManagerService {
         while (durationMS > compute(new Date(), startOf)) {
             // attempt a status check, if successful call it good and return
             // otherwise retry until duration is exceeded
-            const res = await http.requestWithRetry(req);
+            let res;
+            try {
+                res = await http.request(req).toPromise();
+            } catch (e) {
+                continue;
+            }
             if (res.status === 200) {
                 Logger.info(`agent ${agentId} is up and responding`);
                 return;

--- a/src/manager/agent.manager.service.ts
+++ b/src/manager/agent.manager.service.ts
@@ -160,23 +160,22 @@ export class AgentManagerService {
             },
         };
 
-        // no point in rushing this
-        await this.delay(1000);
         const startOf = new Date();
         while (durationMS > compute(new Date(), startOf)) {
+            // no point in rushing this
+            await this.delay(1000);
+
             // attempt a status check, if successful call it good and return
             // otherwise retry until duration is exceeded
-            let res;
             try {
-                res = await http.request(req).toPromise();
+                const res = await http.request(req).toPromise();
+                if (res.status === 200) {
+                    Logger.info(`agent ${agentId} is up and responding`);
+                    return;
+                }
             } catch (e) {
-                continue;
+                // Do nothing and try again
             }
-            if (res.status === 200) {
-                Logger.info(`agent ${agentId} is up and responding`);
-                return;
-            }
-
             await this.delay(1000);
             Logger.info(`pingConnectionWithRetry is retrying`);
         }


### PR DESCRIPTION
Use request instead of requestWithRetry and handle exception on request failure
Signed-off-by: Jacob Saur <jsaur@kiva.org>