### PR TITLE
Add explicit timeouts to tests that set up an agent

### DIFF
--- a/test/agents.e2e-spec.ts
+++ b/test/agents.e2e-spec.ts
@@ -41,7 +41,7 @@ describe('Agency Integration Tests', () => {
                 adminPort1 = res.body.adminPort;
                 agentId1 = res.body.agentId;
             });
-    });
+    }, 10000);
 
     it('Spin up agent 2', async () => {
         const data = {
@@ -59,7 +59,7 @@ describe('Agency Integration Tests', () => {
                 adminPort2 = res.body.adminPort;
                 agentId2 = res.body.agentId;
             });
-    });
+    }, 10000);
 
     it('Get connection data from agent 1', async () => {
         await delayFunc(15000); // wait 20 sec

--- a/test/connections.policies.e2e-spec.ts
+++ b/test/connections.policies.e2e-spec.ts
@@ -49,7 +49,7 @@ describe('Create Connections using policies (e2e)', () => {
                 issuerAdminPort = res.body.adminPort;
                 issuerId = res.body.agentId;
             });
-    });
+    }, 10000);
 
     it('Spin up agent 2 (holder)', async () => {
         const data = {
@@ -69,7 +69,7 @@ describe('Create Connections using policies (e2e)', () => {
                 holderAdminPort = res.body.adminPort;
                 holderId = res.body.agentId;
             });
-    });
+    }, 10000);
 
     it('Create connection invite to holder from issuer', async () => {
         // gonna wait here to let the system catch up since since spawning agents


### PR DESCRIPTION
Add explicit timeouts to tests that set up an agent

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>