### PR TITLE
Production Dockerfile should use a nonroot user to run the app

### DIFF
--- a/docker/Dockerfile.production
+++ b/docker/Dockerfile.production
@@ -14,4 +14,6 @@ FROM node:carbon-alpine
 WORKDIR /www
 COPY --from=node_modules /tmp/node_modules ./node_modules
 COPY --from=dist /tmp/dist ./dist
+RUN adduser -S app
+USER app
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
Production Dockerfile should run app as a nonroot user

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>