### PR TITLE
k8s: use dockerfile entrypoint with args rather than cmd

### DIFF
--- a/src/manager/k8s.service.ts
+++ b/src/manager/k8s.service.ts
@@ -59,7 +59,7 @@ export class K8sService implements IAgentManager {
                 name: 'admin',
                 containerPort: parseInt(config.adminPort, 10)
               }],
-                command: [
+                args: [
               'start',
               '--inbound-transport', inboundTransportSplit[0],  inboundTransportSplit[1], inboundTransportSplit[2],
               '--outbound-transport', config.outboundTransport,


### PR DESCRIPTION
Signed-off-by: Anthony Voutas <anthonyv@kiva.org>