### PR TITLE
Fix typo

### DIFF
--- a/src/manager/k8s.service.ts
+++ b/src/manager/k8s.service.ts
@@ -117,7 +117,7 @@ export class K8sService implements IAgentManager {
                 // Only launch the agents on the dedicated agent node pool if it exists:
                 tolerations: [{
                     key: 'agent',
-                    operator: 'equal',
+                    operator: 'Equal',
                     value: 'true',
                     effect: 'NoSchedule'
                 }],


### PR DESCRIPTION
Looks like this is causing k8s errors: 
https://app.datadoghq.com/logs?cols=core_host%2Ccore_service&context_event=AQAAAXTFqXfSNhsplAAAAABBWFRGcVlKdElTVzc2ZHVVbFFBRg&event=&from_ts=1601040494658&index=main&live=false&messageDisplay=inline&query=host%3Ai-0e6b481ec735b2a81+service%3Aaries-guardianship-agency+container_id%3A289f0ef323b03cf258249c9b040b0ee1a573cc2e01f4ed17bc00bdfcaa857a5a&saved_view&stream_sort=desc&to_event=AQAAAXTFqiw21k5V5QAAAABBWFRGcWpSNmp3dS1EdFFobXdBQg&to_ts=1601044098102
Signed-off-by: Jacob Saur <jsaur@kiva.org>