### PR TITLE
Clear out old remove wallet job

### DIFF
--- a/src/multitenant/mulittenant.service.ts
+++ b/src/multitenant/mulittenant.service.ts
@@ -49,7 +49,7 @@ export class MultitenantService {
         const ttl = (body.ttl === null || body.ttl === undefined) ? this.DEFAULT_TTL_SECONDS : body.ttl;
         // Set remove job
         const timeoutId = await this.setRemoveJob(walletId, body.walletKey, ttl);
-        
+
         // Add to cache
         await this.addWalletToCache(body.walletName, body.walletKey, walletId, token, timeoutId, ttl);
 

--- a/src/multitenant/mulittenant.service.ts
+++ b/src/multitenant/mulittenant.service.ts
@@ -46,15 +46,15 @@ export class MultitenantService {
             }
         }
 
-        // Add to cache
         const ttl = (body.ttl === null || body.ttl === undefined) ? this.DEFAULT_TTL_SECONDS : body.ttl;
-        let invitation = null;
-        await this.addWalletToCache(body.walletName, body.walletKey, walletId, token, ttl);
-
         // Set remove job
-        await this.setRemoveJob(walletId, body.walletKey, ttl);
+        const timeoutId = await this.setRemoveJob(walletId, body.walletKey, ttl);
+        
+        // Add to cache
+        await this.addWalletToCache(body.walletName, body.walletKey, walletId, token, timeoutId, ttl);
 
         // Handle auto connect
+        let invitation = null;
         if (body.autoConnect) {
             invitation = await this.callCreateConnection(token);
         }
@@ -86,11 +86,12 @@ export class MultitenantService {
 
     /**
      * Saves wallet info to cache for easy future access
+     * Note that removing the wallet doesn't involve the cache so no need to add a second to ttl
      */
-    private async addWalletToCache(walletName: string, walletKey: string, walletId: string, token: string, ttl: number): Promise<void> {
-        // Generally we want the cache to last 1 second longer than the agent, except when set to an "infinite" value like 0 or -1
-        const cacheTtl = (ttl < 0) ? ttl : ttl + 1;
-        Logger.debug(`record cache limit set to: ${cacheTtl}`);
+    private async addWalletToCache(
+        walletName: string, walletKey: string, walletId: string, token: string, timeoutId: number, ttl: number
+    ): Promise<void> {
+        Logger.debug(`record cache limit set to: ${ttl}`);
         await this.cache.set(
             walletName,
             {
@@ -99,10 +100,11 @@ export class MultitenantService {
                 walletId,
                 walletKey,
                 ttl,
-                multitenant: true
+                multitenant: true,
+                timeoutId
             },
             {
-                ttl: cacheTtl
+                ttl
             }
         );
     }
@@ -110,10 +112,12 @@ export class MultitenantService {
     /**
      * Sets a job in the future to remove/unregister the wallet after it's ttl has expired
      * ttl = time to live is expected to be in seconds (which we convert to milliseconds).  if 0, then live in eternity
+     * Returns the NodeJS timeout id so that we can remove this timeout if the same wallet is added again later
+     *   Note clearTimeout doesn't error on null so it's fine to return null if we don't set a job
      */
-    private setRemoveJob(walletId: string, walletKey: string, ttl: number): void {
+    private setRemoveJob(walletId: string, walletKey: string, ttl: number): number {
         if (ttl > 0) {
-            setTimeout(
+            const timeout = setTimeout(
                 async () => {
                     try {
                         await this.callRemoveWallet(walletId, walletKey);
@@ -121,18 +125,23 @@ export class MultitenantService {
                         Logger.warn(`Error auto-removing wallet ${walletId}`, e);
                     }
                 }, ttl * 1000);
+            // The NodeJS.Timeout object can't be JSON.stringified (and cached) so we need to coerce to a primitive
+            return timeout[Symbol.toPrimitive]();
         }
+        return null;
     }
 
     /**
      * Handle case where wallet has already be created and registered with multitenant
      * We check the cache and return the wallet id and token
-     * TODO handle case where wallet isn't in cache
+     * Note: we also have special handling to extend the remove job, so we clear out the old timeout here
      */
     private async getTokenAndWalletId(walletName: string, walletKey: string): Promise<[string, string]> {
         const agent: any = await this.cache.get(walletName);
         if (agent) {
             if (agent.walletKey === walletKey) {
+                // before we return we need clear out the old remove wallet timeout
+                clearTimeout(agent.timeoutId);
                 return [agent.walletId, agent.token];
             }
             Logger.warn(`Attempted to open wallet for walletName ${walletName} from cache but with wrong walletKey`);

--- a/test/multitenant.cache.e2e-spec.ts
+++ b/test/multitenant.cache.e2e-spec.ts
@@ -6,10 +6,6 @@ import { ProtocolUtility } from 'protocol-common/protocol.utility';
  * Ensures our system works correctly when attempting to create wallets multiple times regardless of cache state
  */
 describe('Check cache behaviors (e2e)', () => {
-    let issuerConnectionId;
-    let issuerToken;
-    let holderInvitation;
-    let holderToken;
     const multitenantApiKey = 'adminApiKey';
     const multitenantUrl = 'http://localhost:3021'
     const hostUrl = 'http://localhost:3010';
@@ -40,6 +36,7 @@ describe('Check cache behaviors (e2e)', () => {
     });
 
     it('Call create wallet a second time to ensure theres no error', async () => {
+        await ProtocolUtility.delay(500);
         const data = {
             label: label1,
             walletName: wallet1Name,

--- a/test/multitenant.cache.e2e-spec.ts
+++ b/test/multitenant.cache.e2e-spec.ts
@@ -6,8 +6,6 @@ import { ProtocolUtility } from 'protocol-common/protocol.utility';
  * Ensures our system works correctly when attempting to create wallets multiple times regardless of cache state
  */
 describe('Check cache behaviors (e2e)', () => {
-    const multitenantApiKey = 'adminApiKey';
-    const multitenantUrl = 'http://localhost:3021'
     const hostUrl = 'http://localhost:3010';
     const label1 = 'label1';
     const wallet1Name = 'wallet1Name';
@@ -68,7 +66,7 @@ describe('Check cache behaviors (e2e)', () => {
     });
 
     it('Call create wallet a second time to ensure theres no error with expired cache', async () => {
-        await ProtocolUtility.delay(1000);
+        await ProtocolUtility.delay(500);
         const data = {
             label: label2,
             walletName: wallet2Name,
@@ -95,14 +93,5 @@ describe('Check cache behaviors (e2e)', () => {
             .expect(200);
     });
 
-    it('Remove wallet for agent 2', () => {
-        const data = {
-            walletName: wallet2Name,
-            walletKey: wallet2Key
-        };
-        return request(hostUrl)
-            .delete('/v2/multitenant')
-            .send(data)
-            .expect(200);
-    });
+    // no need to remove agent 2 wallet as it's not in cache
 });

--- a/test/multitenant.credential.e2e-spec.ts
+++ b/test/multitenant.credential.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Issue and Prove credentials using policies (e2e)', () => {
     let holderToken;
     const issuerAdminPort = 5011;
     const hostUrl = 'http://localhost:3010';
-    const schemaName = 'sample_schema';
+    const schemaName = 'score_schema';
     const schemaVersion = '1.0';
     const issuerDid = 'Th7MpTaRZVRYnPiabds81Y';
     const walletNameHolder = 'walletNameHolder'
@@ -93,7 +93,10 @@ describe('Issue and Prove credentials using policies (e2e)', () => {
         const data = {
             schema_version: schemaVersion,
             schema_name: schemaName,
-            attributes: [ 'score' ]
+            attributes: [ 
+                'score',
+                'secret_score'
+            ]
         };
         return request(issuerUrl)
             .post('/schemas')
@@ -142,6 +145,10 @@ describe('Issue and Prove credentials using policies (e2e)', () => {
                     {
                         name: 'score',
                         value: '750'
+                    },
+                    {
+                        name: 'secret_score',
+                        value: '25'
                     }
                 ]
             },
@@ -194,7 +201,18 @@ describe('Issue and Prove credentials using policies (e2e)', () => {
                         ]
                     }
                 },
-                requested_predicates: {}
+                requested_predicates: {
+                    'score_under_50': {
+                        name: 'secret_score',
+                        p_type: "<=",
+                        p_value: 50,
+                        restrictions: [
+                            {
+                                cred_def_id: credentialDefinitionId
+                            }
+                        ]
+                    }
+                }
             }
         };
         Logger.warn(`For issuer ${issuerId} /present-proof/send-request body request '${issuerUrl}' -> `, data);
@@ -215,7 +233,7 @@ describe('Issue and Prove credentials using policies (e2e)', () => {
     });
 
     it('verify proof is proved', async () => {
-        await ProtocolUtility.delay(500);
+        await ProtocolUtility.delay(1000);
         return request(issuerUrl)
             .get(`/present-proof/records/${presentationExchangeId}`)
             .set('x-api-key', issuerApiKey)


### PR DESCRIPTION
In response to https://kiva.atlassian.net/browse/PRO-2956
Essentially the issue is that if you call register wallet on multitenant twice it creates two setTimeout jobs to remove the wallet, and when the second one runs the wallet has already been removed so it logs the error. To fix it properly, when we call register wallet the second time, it should extend the original ttl, ie we should clear the old timeout and register a new timeout, so there is only one timeout reflecting the new ttl from that moment.
Signed-off-by: Jacob Saur <jsaur@kiva.org>