### PR TITLE
PRO-2597: Use Protocol Logger, not NestJS Logger

### DIFF
--- a/src/app/global.cache.module.ts
+++ b/src/app/global.cache.module.ts
@@ -1,6 +1,7 @@
-import { Global, Module, CacheModule, Logger } from '@nestjs/common';
+import { Global, Module, CacheModule } from '@nestjs/common';
 import * as fsStore from 'cache-manager-fs-hash';
 import * as redisStore from 'cache-manager-redis-store';
+import { Logger } from 'protocol-common/logger';
 
 /**
  * Supports both a redis cache in our deployed environments, and a file system cache for local testing

--- a/src/manager/agent.manager.module.ts
+++ b/src/manager/agent.manager.module.ts
@@ -1,4 +1,4 @@
-import { Module, HttpModule, HttpService } from '@nestjs/common';
+import { Module, HttpModule } from '@nestjs/common';
 import { AgentManagerService } from './agent.manager.service';
 import { AgentManagerController } from './agent.manager.controller';
 import { GlobalCacheModule } from '../app/global.cache.module';

--- a/src/router/agent.router.service.ts
+++ b/src/router/agent.router.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, CacheStore, Inject, CACHE_MANAGER } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Logger } from 'protocol-common/logger';
 
 /**

--- a/src/transactions/transaction.controller.ts
+++ b/src/transactions/transaction.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Param, Body } from '@nestjs/common';
+import { Controller, Post, Param, Body } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { ProtocolValidationPipe } from 'protocol-common/validation/protocol.validation.pipe';
 import { TransactionService } from './transaction.service';

--- a/src/transactions/transaction.module.ts
+++ b/src/transactions/transaction.module.ts
@@ -1,4 +1,4 @@
-import { Module, HttpModule, forwardRef } from '@nestjs/common';
+import { Module, HttpModule } from '@nestjs/common';
 import { AgentModule } from 'aries-controller/agent/agent.module';
 import { AgentGovernanceFactory } from 'aries-controller/controller/agent.governance.factory';
 import { GlobalCacheModule } from '../app/global.cache.module';


### PR DESCRIPTION
* Use Protocol Logger, not NestJS Logger
* Clean up some unused imports from @nestjs/common