### PR TITLE
Add a simple script that sets up environment variables.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: setup shell environment
           command: |
-            cp dummy.env .env
+            ./scripts/setup_env.sh
             echo ' [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
       - run:
           name: node npm setup

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cp dummy.env .env


### PR DESCRIPTION
As part of the integration test project, it's helpful to have a script in each repository that sets up environment variables for that repository. In the case of the aries-guardianship-agency, it happens to be a very simple script with one line, but it makes automation much easier.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>