### PR TITLE
Remove use of ts-node in favor of directly using node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,9 @@ jobs:
           name: Start docker compose and wait for readiness
           command: |
             docker network ls
-            docker-compose -f docker-compose.ci.yml build
+            docker-compose -f docker-compose.ci.yml build --no-cache
             set -x
-            docker-compose -f docker-compose.ci.yml up -d
+            docker-compose -f docker-compose.ci.yml up --force-recreate -d
             sleep 20
             docker-compose -f docker-compose.ci.yml logs
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
       - run:
           name: node npm setup
           command: |
-              npm install nodemon --save-dev
               npm install
               nvm install v14.15.1
               node -v

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,7 +14,7 @@ networks:
             subnet: 10.0.0.0/24
 
 services:
-      # indy pool needs a static ip configured in the pool_transactions_genesis so need to start it first
+  # indy pool needs a static ip configured in the pool_transactions_genesis so need to start it first
   indy-pool:
     build:
       context: .
@@ -57,9 +57,8 @@ services:
       dockerfile: docker/Dockerfile.production
     env_file:
       - .env
-    image: aries-guardianship-agency
+    image: aries-guardianship-agency:latest
     container_name: aries-guardianship-agency
-    working_dir: /www
     ports:
       - "3010:3010"
     expose: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,10 +57,8 @@ services:
       dockerfile: docker/Dockerfile
     env_file:
       - .env
-    command: npm run start:debug
-    image: aries-guardianship-agency
+    image: aries-guardianship-agency:latest
     container_name: aries-guardianship-agency
-    working_dir: /www
     ports:
       - "3010:3010"
     expose: 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1356,12 +1356,6 @@
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.6.tgz",
       "integrity": "sha512-cK4XqrLvP17X6c0C8n4iTbT59EixqyXL3Fk8/Rsk4dF3oX4dg70gYUXrXVUUHpnsGMPNlTQMqf+TVmNPX6FmSQ=="
     },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true
-    },
     "@types/keyv": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
@@ -1676,12 +1670,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
-    },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -2829,12 +2817,6 @@
         "object-assign": "^4",
         "vary": "^1"
       }
-    },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -9101,43 +9083,6 @@
         }
       }
     },
-    "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-      "dev": true,
-      "requires": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      }
-    },
-    "tsconfig-paths": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-      "dev": true,
-      "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.0",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
-      }
-    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -10034,12 +9979,6 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
     },
     "zen-observable": {
       "version": "0.8.15",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,10 @@
     "url": "git+https://github.com/kiva/protocol.git"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist/ && tsc",
     "format": "prettier --write \"src/**/*.ts\"",
-    "start": "ts-node -r tsconfig-paths/register -r dotenv/config src/main.ts",
+    "start": "rm -rf dist/ && tsc && node -r dotenv/config dist/main.js",
     "start:debug": "nodemon --legacy-watch",
-    "prestart:prod": "rimraf dist && tsc",
-    "start:prod": "node dist/main.js",
-    "start:hmr": "node dist/server",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "lint:fix": "tslint -p tsconfig.json -c tslint.json --fix",
     "test": "node -r dotenv/config node_modules/.bin/jest --runInBand",
@@ -62,8 +59,6 @@
     "rimraf": "^3.0.2",
     "supertest": "^6.1.3",
     "ts-jest": "^26.5.3",
-    "ts-node": "^9.1.1",
-    "tsconfig-paths": "^3.9.0",
     "tslint": "^6.1.3"
   },
   "jest": {
@@ -91,6 +86,6 @@
     "ignore": [
       "src/**/*.spec.ts"
     ],
-    "exec": "ts-node -r tsconfig-paths/register -r dotenv/config src/main.ts"
+    "exec": "tsc && node -r dotenv/config dist/main.js"
   }
 }

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -10,7 +10,7 @@ export function OrmConfig(): DynamicModule {
         synchronize: false,
         migrationsRun: true,
         entities: ['src/transactions/persistence/**/*.ts', 'dist/transactions/persistence/**/*.js'],
-        migrations: ['src/migration/**/*.ts', 'dist/migration/**/*.js'],
+        migrations: ['dist/migration/**/*.js'],
         host: process.env.WALLET_DB_HOST,
         username: process.env.WALLET_DB_USER,
         password: process.env.WALLET_DB_PASS,


### PR DESCRIPTION
Resolves #155 

Summary of Changes
---
- Circle CI config use of the aries-guardianship-agency image and container should make sure not to use a cached copy of either
- docker-compose files don't need to redundantly declare things that have already been declared in the corresponding Dockerfile (e.g. working directory, command to execute)
- Update npm and nodemon commands to use node instead of ts-node
- Remove ts-node and tsconfig-paths dependencies, since they're no longer needed
- Update ormconfig to only references the compiled .js migrations in order to avoid developers accidentally referencing duplicate migrations (Note: with the updated npm commands, there should be no additional developer burden since the build command is now included in the start command)

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>