### PR TITLE
adding a flag that will trigger the TDC to get some extra data

### DIFF
--- a/src/transactions/transaction.service.ts
+++ b/src/transactions/transaction.service.ts
@@ -134,7 +134,7 @@ export class TransactionService {
     }
 
     public async getOneTimeKeyIds(agentId: string, body: RegisterOneTimeKeyDto): Promise<any> {
-        const url = `${body.tdcEndpoint}/v2/transactions/ids/${body.oneTimeKey}`;
+        const url = `${body.tdcEndpoint}/v2/transactions/ids/${body.oneTimeKey}/tro`;
         Logger.debug(`calling TDC ${url}`);
         const request: AxiosRequestConfig = {
             method: 'GET',


### PR DESCRIPTION
Signed-off-by: Matt Raffel <mattr@kiva.org>

adding a flag that will trigger the TDC to get some extra data for the TRO.  this is a work around to our requirement (which we are still working towards) of not having a separate database for TROs.