### PR TITLE
dont remove wallet

### DIFF
--- a/src/multitenant/multitenant.controller.ts
+++ b/src/multitenant/multitenant.controller.ts
@@ -24,7 +24,7 @@ export class MultitenantController {
     }
 
     /**
-     * Remove a wallet from multitenant memory (this doesn't delete the wallet DB record, just the easy access)
+     * Remove a wallet from multitenant - this will remove all stored credentials so only use when you want to fully delete
      */
     @Delete()
     public async removeWallet(@Body(new ProtocolValidationPipe()) body: WalletRemoveDto) {


### PR DESCRIPTION
So... it turns out that calling remove on multitenant doesn't just unregister the wallet from memory, it actually deletes all the credentials in the wallet. We initially had this pattern of "removing" agents when we were spinning up and down docker containers and so I just applied it to multitenant too. However it seems like there's no need to ever call remove with multitenant, so just removing the timed job completely.
Signed-off-by: Jacob Saur <jsaur@kiva.org>